### PR TITLE
Add OopsSec Store to Off-Line vulnerable applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Name  |  Description
 Name  |  Description
 ----  |  ----
 [Damn Vulnerable Xebia Training Environment](https://github.com/davevs/dvxte) | Docker Container including several vulnerable web applications (DVWA, DVWServices, DVWSockets, WebGoat, Juiceshop, Railsgoat, django.NV, Buggy Bank, Mutilidae II and more)
+[OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) | An intentionally vulnerable e-commerce app built with Next.js for web security training (OWASP Top 10, API security, CTF challenges). Quick start with `npx create-oss-store`.
 [OWASP Vulnerable Web Applications Directory Project (Offline)](https://www.owasp.org/index.php/OWASP_Vulnerable_Web_Applications_Directory_Project#tab=Off-Line_apps) | List of offline available vulnerable applications for learning purposes
 
 


### PR DESCRIPTION
This PR adds [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) to the Off-Line learning platforms section.

OopsSec Store is an open-source, intentionally vulnerable e-commerce application built with Next.js and React. It covers OWASP Top 10 vulnerabilities, API security flaws, and modern frontend attack vectors, with CTF challenges and hidden flags to discover.

The project can be quickly set up using `npx create-oss-store` or `docker run -p 3000:3000 leogra/oss-oopssec-store` and provides a production-like application environment with REST APIs.

Repository: https://github.com/kOaDT/oss-oopssec-store