### PR TITLE
Add HTB Writeups to Online learning platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Name  |  Description
 [CyberSec WTF](https://cybersecurity.wtf/)| Emulated web pentesting challenges from bounty write-ups
 [Pentest-Ground](https://pentest-ground.com/) | Pentest Ground is a free playground with deliberately vulnerable web applications and network services.
 [pwn.guide](https://pwn.guide/) | A cybersecurity education website, offering about 100 tutorials, ranging from web, wireless... hacking to defense tutorials & forensics. Offers free plan.
+[HTB Writeups](https://github.com/momenbasel/htb-writeups) | The most comprehensive collection of Hack The Box writeups on GitHub - 500+ machines, 400+ challenges, ProLabs, Sherlocks (DFIR), endgames, and CTF events with full walkthroughs.
 
 ### Off-Line
 Name  |  Description


### PR DESCRIPTION
## Summary

Adds [HTB Writeups](https://github.com/momenbasel/htb-writeups) to the **Online** learning platforms table. This is the most comprehensive collection of Hack The Box writeups on GitHub, covering:

- **500+ machines** organized by difficulty (Easy through Insane)
- **400+ challenges** across 12 categories (Web, Crypto, Pwn, Reversing, Forensics, etc.)
- **6 ProLabs** - enterprise-grade lab walkthroughs (Dante, Offshore, RastaLabs, etc.)
- **38+ Sherlocks** - DFIR and Blue Team investigations
- **6 CTF events**, **5 Endgames**, **6 Fortresses**
- Tools, cheatsheets, methodology guides, and certification prep resources (OSCP, CPTS, CRTO)

Each writeup includes step-by-step enumeration, exploitation, and privilege escalation with full command output. A structured, searchable index of the entire HTB ecosystem for anyone learning ethical hacking and penetration testing.

## Format

Follows the existing `Name | Description` table format used in the Online section.